### PR TITLE
ocaml's ldconf cleanup.

### DIFF
--- a/Formula/ocaml-aacplus.rb
+++ b/Formula/ocaml-aacplus.rb
@@ -15,6 +15,8 @@ class OcamlAacplus < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-ao.rb
+++ b/Formula/ocaml-ao.rb
@@ -14,6 +14,8 @@ class OcamlAo < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-bjack.rb
+++ b/Formula/ocaml-bjack.rb
@@ -14,6 +14,8 @@ class OcamlBjack < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-camlimages.rb
+++ b/Formula/ocaml-camlimages.rb
@@ -17,6 +17,7 @@ class OcamlCamlimages < Formula
   
   def install
     ENV['OCAMLFIND_DESTDIR'] = "#{lib}/ocaml/site-lib"
+    ENV['OCAMLFIND_LDCONF'] = 'ignore'
     inreplace "OMakefile", "/usr/include/X11", "/usr/include\n  /usr/X11/include\n  #{HOMEBREW_PREFIX}/include/X11"
     # Waiting for LibPng 1.5 bundled in MacOSX Lion to be supported in CamlImages
     # inreplace "OMakefile", "LDFLAGS[]+=", "LDFLAGS[]+= -L/usr/X11/lib"
@@ -24,5 +25,7 @@ class OcamlCamlimages < Formula
     system 'omake'
     mkdir_p "#{prefix}/lib/ocaml/site-lib"
     system "omake install"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-cryptokit.rb
+++ b/Formula/ocaml-cryptokit.rb
@@ -14,6 +14,8 @@ class OcamlCryptokit < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-dssi.rb
+++ b/Formula/ocaml-dssi.rb
@@ -16,6 +16,8 @@ class OcamlDssi < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-duppy.rb
+++ b/Formula/ocaml-duppy.rb
@@ -15,6 +15,8 @@ class OcamlDuppy < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-faac.rb
+++ b/Formula/ocaml-faac.rb
@@ -14,6 +14,8 @@ class OcamlFaac < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-faad.rb
+++ b/Formula/ocaml-faad.rb
@@ -14,6 +14,8 @@ class OcamlFaad < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -8,7 +8,7 @@ class OcamlFindlib < Formula
   depends_on 'objective-caml' => :build
 
   def install
-    system './configure', '-config',  "#{prefix}/etc/findlib.conf", "-sitelib", "#{lib}/ocaml/site-lib", "-system", "osx", "-bindir", "#{bin}", "-mandir", "#{man}", "-with-toolbox"
+    system './configure', '-config',  "#{etc}/findlib.conf", "-sitelib", "#{HOMEBREW_PREFIX}/lib/ocaml/site-lib", "-system", "osx", "-bindir", "#{bin}", "-mandir", "#{man}", "-with-toolbox"
     system 'make'
     system 'make opt'
     mkdir_p "#{lib}/ocaml/site-lib"

--- a/Formula/ocaml-flac.rb
+++ b/Formula/ocaml-flac.rb
@@ -16,6 +16,8 @@ class OcamlFlac < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-gavl.rb
+++ b/Formula/ocaml-gavl.rb
@@ -14,6 +14,8 @@ class OcamlGavl < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-gstreamer.rb
+++ b/Formula/ocaml-gstreamer.rb
@@ -17,6 +17,8 @@ class OcamlGstreamer < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-ladspa.rb
+++ b/Formula/ocaml-ladspa.rb
@@ -14,6 +14,8 @@ class OcamlLadspa < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-lame.rb
+++ b/Formula/ocaml-lame.rb
@@ -14,8 +14,10 @@ class OcamlLame < Formula
     ENV.gcc if MacOS.xcode_version < "4.2"
     ENV['OCAMLFIND_DESTDIR'] = "#{lib}/ocaml/site-lib"
     system "./configure", "--prefix=#{prefix}"
-    system "make"
+    system "make -j1"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-lo.rb
+++ b/Formula/ocaml-lo.rb
@@ -14,6 +14,8 @@ class OcamlLo < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-mad.rb
+++ b/Formula/ocaml-mad.rb
@@ -14,6 +14,8 @@ class OcamlMad < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-magic.rb
+++ b/Formula/ocaml-magic.rb
@@ -14,6 +14,8 @@ class OcamlMagic < Formula
     system './configure'
     system 'make'
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make", "install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-mm.rb
+++ b/Formula/ocaml-mm.rb
@@ -18,6 +18,8 @@ class OcamlMm < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-net.rb
+++ b/Formula/ocaml-net.rb
@@ -17,6 +17,8 @@ class OcamlNet < Formula
     system "./configure", "-enable-pcre", "-enable-ssl", "-disable-zip", "-enable-crypto", "-bindir", "#{prefix}/bin", "-datadir", "#{lib}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-ogg.rb
+++ b/Formula/ocaml-ogg.rb
@@ -14,6 +14,8 @@ class OcamlOgg < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-pcre.rb
+++ b/Formula/ocaml-pcre.rb
@@ -14,6 +14,8 @@ class OcamlPcre < Formula
     ENV['OCAMLFIND_DESTDIR'] = "#{lib}/ocaml/site-lib"
     system 'make'
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make", "install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-portaudio.rb
+++ b/Formula/ocaml-portaudio.rb
@@ -14,6 +14,8 @@ class OcamlPortaudio < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-samplerate.rb
+++ b/Formula/ocaml-samplerate.rb
@@ -14,6 +14,8 @@ class OcamlSamplerate < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-schroedinger.rb
+++ b/Formula/ocaml-schroedinger.rb
@@ -16,6 +16,8 @@ class OcamlSchroedinger < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-sdl.rb
+++ b/Formula/ocaml-sdl.rb
@@ -19,6 +19,8 @@ class OcamlSdl < Formula
     system './configure', "--prefix=#{prefix}"
     system 'make'
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make", "install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stub.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-shout.rb
+++ b/Formula/ocaml-shout.rb
@@ -14,6 +14,8 @@ class OcamlShout < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-soundtouch.rb
+++ b/Formula/ocaml-soundtouch.rb
@@ -15,6 +15,8 @@ class OcamlSoundtouch < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-speex.rb
+++ b/Formula/ocaml-speex.rb
@@ -16,6 +16,8 @@ class OcamlSpeex < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-ssl.rb
+++ b/Formula/ocaml-ssl.rb
@@ -17,7 +17,9 @@ class OcamlSsl < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end
 

--- a/Formula/ocaml-syslog.rb
+++ b/Formula/ocaml-syslog.rb
@@ -13,6 +13,8 @@ class OcamlSyslog < Formula
     system "make"
     system "make opt"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-taglib.rb
+++ b/Formula/ocaml-taglib.rb
@@ -10,10 +10,12 @@ class OcamlTaglib < Formula
   depends_on 'taglib' => :build
 
   def install
-      ENV['OCAMLFIND_DESTDIR'] = "#{lib}/ocaml/site-lib"
-      system "./configure", "--prefix=#{prefix}"
-      system "make"
-      mkdir_p "#{lib}/ocaml/site-lib"
-      system "make install"
-    end
+    ENV['OCAMLFIND_DESTDIR'] = "#{lib}/ocaml/site-lib"
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    mkdir_p "#{lib}/ocaml/site-lib"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
+  end
 end

--- a/Formula/ocaml-theora.rb
+++ b/Formula/ocaml-theora.rb
@@ -16,6 +16,8 @@ class OcamlTheora < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-voaacenc.rb
+++ b/Formula/ocaml-voaacenc.rb
@@ -14,6 +14,8 @@ class OcamlVoaacenc < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-vorbis.rb
+++ b/Formula/ocaml-vorbis.rb
@@ -16,6 +16,8 @@ class OcamlVorbis < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib"
-    system "make install"
+    system "make install OCAMLFIND_LDCONF=ignore"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv #{lib}/ocaml/site-lib/*/*stubs.so #{lib}/ocaml/stublibs"
   end
 end

--- a/Formula/ocaml-zip.rb
+++ b/Formula/ocaml-zip.rb
@@ -11,6 +11,8 @@ class OcamlZip < Formula
     inreplace "Makefile", "INSTALLDIR=`$(OCAMLC) -where`/zip", "INSTALLDIR=#{lib}/ocaml/site-lib/zip"
     system "make"
     mkdir_p "#{lib}/ocaml/site-lib/zip"
+    mkdir_p "#{lib}/ocaml/stublibs"
+    system "mv dllcamlzip.so #{lib}/ocaml/stublibs"
     system "make install"
   end
 end


### PR DESCRIPTION
Hi!

I've been testing the `devel` branch.. Impressive work!

One issue that I've encountered is that all OCaml modules which build a shared `.so` object install it in the respectice `Cellar/lib/ocaml/site-lib/foo` directory and then add this path to OCaml's `ld.conf`.

This is a problem as those cellar path should not be exposed.. The following patch fixes this the same way as is done in Debian: install `.so` files in `ocaml/stublibs` and disable `ld.config`
