### PR TITLE
fix deprecation warnings in homebrew

### DIFF
--- a/Formula/liquidsoap.rb
+++ b/Formula/liquidsoap.rb
@@ -134,7 +134,7 @@ class Liquidsoap < Formula
   homepage 'http://liquidsoap.fm/'
   sha256 '03990cbe21dc41b0aeeda60fcaaf5c2c48707c418724fe88abc1c57a5fa15ef5'
 
-  unless MacOS.snow_leopard? or MacOS.lion? or MacOS.mountain_lion?
+  unless MacOS.version >= :snow_leopard
     onoe 'Sorry!'
     onoe 'We currently does not support MacOSX older than 10.6, '
     onoe 'try old Macports way described here -> http://savonet.sourceforge.net/macports.html'
@@ -307,12 +307,12 @@ index 586c13e..e208b5a 100644
                else
 @@ -252,7 +252,7 @@ let external_input_oblivious process filename prebuf =
    in
-   let read len = 
+   let read len =
      if not !process_done then
 -      let ret = String.create len in
 +      let ret = Bytes.to_string (Bytes.create len) in
        let read = Unix.read pull_e ret 0 len in
-       if read = 0 then close () ; 
+       if read = 0 then close () ;
        ret,read
 diff --git a/src/decoder/image/ppm_decoder.ml b/src/decoder/image/ppm_decoder.ml
 index 720b5c1..39830ad 100644
@@ -536,7 +536,7 @@ index 8d954e6..b362714 100644
        if pos=size then buf else
          let p = Unix.read socket buf pos (size-pos) in
 @@ -84,7 +84,7 @@ let read_metadata () = let old_chunk = ref "" in fun socket ->
- 
+
  let read_line socket =
    let ans = ref "" in
 -  let c = String.create 1 in
@@ -683,11 +683,10 @@ index 16e745c..f53718d 100644
    in
 @@ -187,7 +187,7 @@ let short_string i =
      (String.make 1 (char_of_int up))
- 
+
  let int_string n =
 -  let s = String.create 4 in
 +  let s = Bytes.to_string (Bytes.create 4) in
      s.[0] <- char_of_int (n land 0xff) ;
      s.[1] <- char_of_int ((n land 0xff00) lsr 8) ;
      s.[2] <- char_of_int ((n land 0xff0000) lsr 16) ;
-

--- a/Formula/ocaml-soundtouch.rb
+++ b/Formula/ocaml-soundtouch.rb
@@ -7,8 +7,8 @@ class OcamlSoundtouch < Formula
 
   depends_on 'objective-caml' => :build
   depends_on 'ocaml-findlib' => :build
-  depends_on "sound-touch" => :build if Hardware.is_32_bit?
-  depends_on "soundtouch" => :build if Hardware.is_64_bit?
+  depends_on "sound-touch" => :build if Hardware::CPU.is_32_bit?
+  depends_on "soundtouch" => :build if Hardware::CPU.is_64_bit?
 
   def install
     ENV.j1


### PR DESCRIPTION
When adding the tap or searching for a formula contained in the tab, deprecation warnings are shown:
```
Warning: Calling MacOS.snow_leopard? is deprecated!
Use 'MacOS.version >= :snow_leopard' instead.
/usr/local/Homebrew/Library/Taps/drfill/homebrew-liquidsoap/Formula/liquidsoap.rb:137:in `<class:Liquidsoap>'
Please report this to the drfill/liquidsoap tap!

Warning: Calling Hardware.is_32_bit? is deprecated!
Use Hardware::CPU.is_32_bit? instead.
/usr/local/Homebrew/Library/Taps/drfill/homebrew-liquidsoap/Formula/ocaml-soundtouch.rb:10:in `<class:OcamlSoundtouch>'
Please report this to the drfill/liquidsoap tap!

Warning: Calling Hardware.is_64_bit? is deprecated!
Use Hardware::CPU.is_64_bit? instead.
/usr/local/Homebrew/Library/Taps/drfill/homebrew-liquidsoap/Formula/ocaml-soundtouch.rb:11:in `<class:OcamlSoundtouch>'
Please report this to the drfill/liquidsoap tap!
```